### PR TITLE
Bump Typescript dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -416,9 +416,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "tslint": "^6.1.1",
     "tslint-config-standard": "^9.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.3.5"
   },
   "dependencies": {
     "ts-tiny-invariant": "0.0.3"


### PR DESCRIPTION
Compiled ts-is-defined code is breaking certain builds because they cant find `ts-tiny-invariant`, I think because the Typescript version is old. 

Related github issue: https://github.com/apollographql/apollo-server/issues/5505